### PR TITLE
Configure Travis as default CI

### DIFF
--- a/lib/code42template/app_builder.rb
+++ b/lib/code42template/app_builder.rb
@@ -98,6 +98,10 @@ module Code42Template
       directory("dotfiles", ".")
     end
 
+    def setup_continuous_integration
+      template "travis.yml.erb", '.travis.yml'
+    end
+
     def init_git
       run 'git init'
     end

--- a/lib/code42template/app_builder.rb
+++ b/lib/code42template/app_builder.rb
@@ -251,7 +251,11 @@ module Code42Template
 
     def setup_bundler_audit
       copy_file "bundler_audit.rake", "lib/tasks/bundler_audit.rake"
-      append_file "Rakefile", %{\ntask default: "bundler:audit"\n}
+    end
+
+    def setup_health_task
+      copy_file "health.rake", "lib/tasks/health.rake"
+      append_file "Rakefile", %{\ntask default: "health"\n}
     end
 
     def setup_webpack_tasks

--- a/lib/code42template/generators/app_generator.rb
+++ b/lib/code42template/generators/app_generator.rb
@@ -35,6 +35,7 @@ module Code42Template
       invoke :setup_test_environment
       invoke :setup_production_environment
       invoke :setup_staging_environment
+      invoke :setup_continuous_integration
       invoke :setup_secret_token
       invoke :create_code42_views
       invoke :configure_app
@@ -111,6 +112,12 @@ module Code42Template
 
     def setup_staging_environment
       say 'Setting up the staging environment'
+    end
+
+    def setup_continuous_integration
+      say 'Setting up CI configuration'
+
+      build :setup_continuous_integration
     end
 
     def setup_secret_token

--- a/lib/code42template/generators/app_generator.rb
+++ b/lib/code42template/generators/app_generator.rb
@@ -157,7 +157,14 @@ module Code42Template
 
     def setup_webpack_tasks
       say "Setting up webpack tasks"
+
       build :setup_webpack_tasks
+    end
+
+    def setup_health_task
+      say "Setting up health task"
+
+      build :setup_health_task
     end
 
     def init_git

--- a/lib/code42template/version.rb
+++ b/lib/code42template/version.rb
@@ -1,5 +1,7 @@
 module Code42Template
   RAILS_VERSION = "~> 5.0.0"
   RUBY_VERSION = Pathname(__dir__).join('..', '..', '.ruby-version').read.strip
+  NODE_VERSION = "6.2.0"
+
   VERSION = "1.0.1"
 end

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -67,7 +67,8 @@ RSpec.describe "Create a new project with default configuration" do
     end
   end
 
-  it 'copies continuous integration setup' do
+  it 'copies health task and continuous integration setup' do
+    expect(File).to exist(file_path('lib/tasks/health.rake'))
     expect(File).to exist(file_path('.travis.yml'))
   end
 

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -67,6 +67,10 @@ RSpec.describe "Create a new project with default configuration" do
     end
   end
 
+  it 'copies continuous integration setup' do
+    expect(File).to exist(file_path('.travis.yml'))
+  end
+
   it "loads secret_key_base from env" do
     secrets_file = IO.read("#{project_path}/config/secrets.yml")
 

--- a/templates/health.rake
+++ b/templates/health.rake
@@ -1,0 +1,22 @@
+if Rails.env.development? || Rails.env.test?
+  def run_command(command)
+    description = "Running '#{command}'"
+    separator = '-' * description.length
+
+    puts '', separator, description, separator, ''
+
+    system("bundle exec #{command}") or fail(
+      "There was an error while running '#{command}'"
+    )
+  end
+
+  desc 'Checks app health: runs tests, security checks and rubocop'
+  task :health do
+    run_command 'rspec'
+    run_command 'npm run test'
+    run_command 'bundle-audit update'
+    run_command 'bundle-audit check'
+    run_command 'brakeman -z'
+    run_command 'rubocop'
+  end
+end

--- a/templates/travis.yml.erb
+++ b/templates/travis.yml.erb
@@ -9,8 +9,4 @@ install:
 before_script:
   - bundle exec rake db:test:prepare
 script:
-  - bundle exec rspec
-  - bundle exec bundle-audit update && bundle exec bundle-audit check
-  - bundle exec brakeman -z
-  - bundle exec rubocop
-  - npm run test
+  - bundle exec rake health

--- a/templates/travis.yml.erb
+++ b/templates/travis.yml.erb
@@ -1,0 +1,16 @@
+language: ruby
+rvm:
+  - <%= Code42Template::RUBY_VERSION %>
+before_install:
+  - nvm install <%= Code42Template::NODE_VERSION %>
+install:
+  - bundle install --jobs=3 --retry=3
+  - npm install
+before_script:
+  - bundle exec rake db:test:prepare
+script:
+  - bundle exec rspec
+  - bundle exec bundle-audit update && bundle exec bundle-audit check
+  - bundle exec brakeman -z
+  - bundle exec rubocop
+  - npm run test


### PR DESCRIPTION
The `rake` or `rake health` command runs the following tasks:

- Ruby specs
- JS specs
- Bundler audit
- Brakeman
- Rubocop

It's also used by Travis.