### PR TITLE
Reamove duplicated Rubocop entry on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Currently the following gems are included by default:
 * [Pry rails](https://github.com/rweng/pry-rails) for open rails console with Pry
 * [Rubocop](https://github.com/bbatsov/rubocop) for static code analysis
 * [Spring commands rspec](https://github.com/jonleighton/spring-commands-rspec) for rspec binstubs with Spring
-* [Rubocop](https://github.com/bbatsov/rubocop) for enforcing the Ruby Style Guide
 * [Rack Mini Profiler](https://github.com/MiniProfiler/rack-mini-profiler) for helping out with performance issues
 * [Simplecov](https://github.com/colszowka/simplecov) for helping out with test coverage
 * [factory_girl_rails](https://github.com/thoughtbot/factory_girl_rails) as a test fixture replacement


### PR DESCRIPTION
There is already an entry to this gem on line 37