### PR TITLE
Configure feature tests

### DIFF
--- a/lib/code42template/app_builder.rb
+++ b/lib/code42template/app_builder.rb
@@ -233,6 +233,16 @@ module Code42Template
       )
     end
 
+    def configure_feature_tests
+      inject_into_file(
+        'config/environments/test.rb',
+        "  config.webpack.dev_server.enabled = false\n",
+        after: "Rails.application.configure do\n",
+      )
+
+      template 'feature_helper.rb.erb', 'spec/feature_helper.rb'
+    end
+
     def add_bullet_gem_configuration
       config = <<~RUBY
         config.after_initialize do

--- a/lib/code42template/generators/app_generator.rb
+++ b/lib/code42template/generators/app_generator.rb
@@ -102,6 +102,7 @@ module Code42Template
 
       build :setup_test_env_action_dispatch_exceptions
       build :copy_rspec_config
+      build :configure_feature_tests
     end
 
     def setup_production_environment

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -19,14 +19,15 @@ RSpec.describe "Create a new project with default configuration" do
   end
 
   it "ensures project specs pass" do
-    FileUtils.cp(
-      Pathname(__dir__).join('..', 'fixtures', 'smoke_test.rb'),
-      Pathname(project_path).join('spec', 'models', 'smoke_test_spec.rb')
-    )
+    copy_file 'smoke_test.rb', 'spec/models/smoke_test_spec.rb'
+    copy_file 'feature_smoke_test.rb', 'spec/models/feature_smoke_spec.rb'
+    copy_file 'routes.rb', 'config/routes.rb'
+    copy_file 'home_controller.rb', 'app/controllers/home_controller.rb'
+    copy_file 'index.html.erb', 'app/views/home/index.html.erb'
 
     Dir.chdir(project_path) do
       Bundler.with_clean_env do
-        expect(`rake`).to include('1 example, 0 failures')
+        expect(`rspec`).to include('3 examples, 0 failures')
         expect(`npm run test`).to include('1 passing', '1 SUCCESS')
       end
     end
@@ -180,5 +181,14 @@ RSpec.describe "Create a new project with default configuration" do
 
   def file_path(path)
     File.join(project_path, path)
+  end
+
+  def copy_file(source_fixture_name, destination_path)
+    source_path = Pathname(__dir__).join('..', 'fixtures', source_fixture_name)
+    destination_path = Pathname(project_path).join(destination_path)
+    destination_dir = destination_path.join('..')
+    FileUtils.mkdir_p(destination_dir) unless destination_dir.exist?
+
+    FileUtils.cp(source_path, destination_path)
   end
 end

--- a/spec/fixtures/feature_smoke_test.rb
+++ b/spec/fixtures/feature_smoke_test.rb
@@ -1,0 +1,15 @@
+require 'feature_helper'
+
+RSpec.feature 'feature smoke test' do
+  it 'works with js', js: true do
+    visit '/'
+
+    expect(page).to have_content('It works!')
+  end
+
+  it 'works without js' do
+    visit '/'
+
+    expect(page).to have_content('It works!')
+  end
+end

--- a/spec/fixtures/home_controller.rb
+++ b/spec/fixtures/home_controller.rb
@@ -1,0 +1,4 @@
+class HomeController < ApplicationController
+  def index
+  end
+end

--- a/spec/fixtures/index.html.erb
+++ b/spec/fixtures/index.html.erb
@@ -1,0 +1,1 @@
+<p>It works!</p>

--- a/spec/fixtures/routes.rb
+++ b/spec/fixtures/routes.rb
@@ -1,0 +1,3 @@
+Rails.application.routes.draw do
+  root to: 'home#index'
+end

--- a/spec/fixtures/smoke_test.rb
+++ b/spec/fixtures/smoke_test.rb
@@ -4,7 +4,7 @@ RSpec.describe 'rails_helper smoke test' do
   it 'is configured correctly' do
     expect(Rails.env).to be_test
     expect(RSpec.configuration.use_transactional_fixtures).to eq true
-    expect(Capybara.javascript_driver).to eq :selenium
+    expect(Capybara.javascript_driver).to eq :poltergeist
     expect(Capybara.default_driver).to eq :rack_test
   end
 end

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -35,7 +35,7 @@ group :test do
   gem 'factory_girl_rails'
   gem 'ffaker'
   gem 'simplecov', require: false
-  #gem 'poltergeist'
+  gem 'poltergeist'
 end
 
 group :staging, :production do

--- a/templates/feature_helper.rb.erb
+++ b/templates/feature_helper.rb.erb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+require 'rake'
+
+<%= app_name.camelize %>::Application.load_tasks
+Rake::Task['webpack:compile'].invoke

--- a/templates/rails_helper.rb
+++ b/templates/rails_helper.rb
@@ -11,8 +11,12 @@ end
 
 require 'spec_helper'
 require 'rspec/rails'
+require 'capybara/poltergeist'
 
 ActiveRecord::Migration.maintain_test_schema!
+
+Capybara.javascript_driver = :poltergeist
+Capybara.default_driver = :rack_test
 
 RSpec.configure do |config|
   config.use_transactional_fixtures = true
@@ -37,10 +41,3 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
   end
 end
-
-# Uncomment if you want to use phantomjs
-#require 'capybara/poltergeist'
-
-# Switch both assignments to :poltergeist if you want to use phantomjs
-Capybara.javascript_driver = :selenium
-Capybara.default_driver = :rack_test


### PR DESCRIPTION
- Have `phantomjs` by default in RSpec feature tests.
- Users must require `feature_helper` in feature tests instead of `rails_helper`, so that it compiles **webpack** assets before running feature specs.
- Use `js: true` as RSpec metadata to run tests which depend on JavaScript. Otherwise `rack_test` driver will be used.