### PR TITLE
Tweak simplecov

### DIFF
--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -27,8 +27,15 @@ RSpec.describe "Create a new project with default configuration" do
 
     Dir.chdir(project_path) do
       Bundler.with_clean_env do
-        expect(`rspec`).to include('3 examples, 0 failures')
-        expect(`npm run test`).to include('1 passing', '1 SUCCESS')
+        expect(`rake health`).to include(
+          '3 examples, 0 failures', # rspec
+          'LOC (100.0%) covered.', # simplecov
+          'no offenses detected', # rubocop
+          'Security Warnings | 0', # brakeman
+          'No vulnerabilities found', # bundler-audit
+          '1 passing', # mocha
+          'TOTAL: 1 SUCCESS' # karma
+        )
       end
     end
   end

--- a/templates/health.rake
+++ b/templates/health.rake
@@ -1,22 +1,22 @@
 if Rails.env.development? || Rails.env.test?
-  def run_command(command)
+  def run_command(command, env = {})
     description = "Running '#{command}'"
     separator = '-' * description.length
 
     puts '', separator, description, separator, ''
 
-    system("bundle exec #{command}") or fail(
-      "There was an error while running '#{command}'"
-    )
+    system(env, command) or fail "There was an error while running '#{command}'"
   end
 
   desc 'Checks app health: runs tests, security checks and rubocop'
   task :health do
-    run_command 'rspec'
+    rails_helper = Rails.root / 'spec/rails_helper.rb'
+
+    run_command "bundle exec rspec -r#{rails_helper}", 'COVERAGE' => 'true'
     run_command 'npm run test'
-    run_command 'bundle-audit update'
-    run_command 'bundle-audit check'
-    run_command 'brakeman -z'
-    run_command 'rubocop'
+    run_command 'bundle exec bundle-audit update'
+    run_command 'bundle exec bundle-audit check'
+    run_command 'bundle exec brakeman -z'
+    run_command 'bundle exec rubocop'
   end
 end

--- a/templates/rails_helper.rb
+++ b/templates/rails_helper.rb
@@ -1,12 +1,28 @@
 ENV['RAILS_ENV'] ||= 'test'
 
-require 'simplecov'
-SimpleCov.start
+if ENV['COVERAGE']
+  require 'simplecov'
+
+  SimpleCov.start 'rails' do
+    minimum_coverage 90
+    refuse_coverage_drop
+
+    add_filter do |source_file|
+      source_file.filename =~ %r{app/channels|lib/tasks}
+    end
+  end
+end
 
 require_relative '../config/environment'
 
 if Rails.env.production?
   abort 'The Rails environment is running in production mode!'
+end
+
+if ENV['COVERAGE']
+  %w(Controller Record Mailer Job).each do |klass|
+    Object.const_get "Application#{klass}"
+  end
 end
 
 require 'spec_helper'


### PR DESCRIPTION
- Use COVERAGE env var to run coverage checks in rspec.
- Run rspec with COVERAGE in `rake health`, and have it always require `rails_helper.rb` in order to correctly trigger coverage.
- Exclude some files from coverage, such as rake tasks and action cable files.
- Setup a minimum of 90% coverage without allowing drops.