### PR TITLE
Add eslint and sinon

### DIFF
--- a/lib/code42template/app_builder.rb
+++ b/lib/code42template/app_builder.rb
@@ -96,6 +96,7 @@ module Code42Template
 
     def copy_dotfiles
       directory("dotfiles", ".")
+      copy_file 'test_env_eslintrc', 'spec/javascripts/.eslintrc'
     end
 
     def setup_continuous_integration

--- a/lib/code42template/generators/app_generator.rb
+++ b/lib/code42template/generators/app_generator.rb
@@ -156,6 +156,7 @@ module Code42Template
 
     def setup_dotfiles
       build :copy_dotfiles
+      build :copy_eslint_config
     end
 
     def setup_default_directories

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -47,9 +47,11 @@ RSpec.describe "Create a new project with default configuration" do
   end
 
   it "copies dotfiles" do
-    %w[.env .rspec .codeclimate.yml].each do |dotfile|
+    %w[.env .rspec .codeclimate.yml .eslintrc .eslintignore].each do |dotfile|
       expect(File).to exist("#{project_path}/#{dotfile}")
     end
+
+    expect(File).to exist("#{project_path}/spec/javascripts/.eslintrc")
   end
 
   it 'copies rspec configuration' do

--- a/templates/application.js
+++ b/templates/application.js
@@ -1,1 +1,1 @@
-(() => console.log('I am alive!'))()
+// This is where you should bootstrap your JS app

--- a/templates/dotfiles/.eslintignore
+++ b/templates/dotfiles/.eslintignore
@@ -1,0 +1,5 @@
+node_modules
+coverage
+webpack.config.*
+karma.conf.js
+app/assets/javascripts/cable.js

--- a/templates/dotfiles/.eslintrc
+++ b/templates/dotfiles/.eslintrc
@@ -1,0 +1,16 @@
+{
+    "extends": "airbnb-base",
+    "env": {
+        "mocha": true
+    },
+    "settings": {
+        "import/resolver": {
+            "webpack": {
+                "config": "config/webpack.config.js"
+            }
+        }
+    },
+    "globals": {
+        "window": true
+    }
+}

--- a/templates/health.rake
+++ b/templates/health.rake
@@ -14,6 +14,7 @@ if Rails.env.development? || Rails.env.test?
 
     run_command "bundle exec rspec -r#{rails_helper}", 'COVERAGE' => 'true'
     run_command 'npm run test'
+    run_command 'npm run lint'
     run_command 'bundle exec bundle-audit update'
     run_command 'bundle exec bundle-audit check'
     run_command 'bundle exec brakeman -z'

--- a/templates/package.json
+++ b/templates/package.json
@@ -15,6 +15,10 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "eslint": "^3.5.0",
+    "eslint-config-airbnb-base": "^7.1.0",
+    "eslint-import-resolver-webpack": "^0.6.0",
+    "eslint-plugin-import": "^1.15.0",
     "karma": "^0.13.22",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^1.0.1",
@@ -29,6 +33,7 @@
     "mocha-webpack": "^0.4.0"
   },
   "scripts": {
+    "lint": "eslint .",
     "test": "npm run test:unit && npm run test:integration",
     "test:unit": "NODE_ENV=test NODE_PATH='./app/assets/javascripts' mocha-webpack",
     "test:unit:watch": "npm run test:unit -- --watch",

--- a/templates/package.json
+++ b/templates/package.json
@@ -30,7 +30,8 @@
     "karma-webpack": "^1.7.0",
     "mocha": "^2.4.5",
     "mocha-loader": "^0.7.1",
-    "mocha-webpack": "^0.4.0"
+    "mocha-webpack": "^0.4.0",
+    "sinon": "^1.17.5"
   },
   "scripts": {
     "lint": "eslint .",

--- a/templates/webpack.config.js
+++ b/templates/webpack.config.js
@@ -24,11 +24,15 @@ var config = {
   module: {
     loaders: [
       { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader' },
-      { test: /\.json$/,   loader: 'json-loader' }
+      { test: /\.json$/,   loader: 'json-loader' },
+      { test: /sinon\.js$/, loader: "imports?define=>false,require=>false"}
     ]
   },
   resolve: {
-    root: path.join(__dirname, '..', 'app', 'assets', 'javascripts')
+    root: path.join(__dirname, '..', 'app', 'assets', 'javascripts'),
+    alias: {
+      sinon: 'sinon/pkg/sinon'
+    }
   },
   plugins: [
     // must match config.webpack.manifest_filename


### PR DESCRIPTION
## eslint

- Use airbnb eslint config
- Also tweaked eslint in test env
- It is integrated with the `rake health` command
- Make it "green" by default

Run eslint with:

```
npm run lint
```

## sinon

- Added to webpack configuration
- Use it with the following import:

```js
import sinon from 'sinon';
```