### PR TITLE
Fix missing ActiveRecord when app generated with --skip-active-record

### DIFF
--- a/templates/puma.rb
+++ b/templates/puma.rb
@@ -24,5 +24,5 @@ environment ENV.fetch("RACK_ENV", "development")
 on_worker_boot do
   # Worker specific setup for Rails 4.1+
   # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
-  ActiveRecord::Base.establish_connection
+  ActiveRecord::Base.establish_connection if defined? ActiveRecord
 end


### PR DESCRIPTION
This fix allows to generate an application without ActiveRecord (--skip-active-record).